### PR TITLE
Fix the issue causing segfault and fix logs

### DIFF
--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -108,7 +108,10 @@ class AdminHandler : virtual public AdminSvIf {
         CompactDBResponse>>> callback,
       std::unique_ptr<CompactDBRequest> request) override;
 
-  void async_tm_tailKafkaMessages(std::unique_ptr<apache::thrift::HandlerCallback<std::unique_ptr< ::admin::TailKafkaMessagesResponse>>> callback, std::unique_ptr< ::admin::TailKafkaMessagesRequest> request) override;
+  void async_tm_tailKafkaMessages(
+      std::unique_ptr<apache::thrift::HandlerCallback<std::unique_ptr<
+          ::admin::TailKafkaMessagesResponse>>> callback,
+          std::unique_ptr< ::admin::TailKafkaMessagesRequest> request) override;
 
   std::shared_ptr<ApplicationDB> getDB(const std::string& db_name,
                                        AdminException* ex);


### PR DESCRIPTION
When the last message of the partition is read, the key is null. Handling that case here. Also, logging the string
representation of the payload.